### PR TITLE
SW-1361 Downgrade Required Ruby Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # DeepNest
 
+## 0.1.2
+
+### Downgrade Required Ruby version
+
+  - Downgraded required Ruby version from 2.7.2 to 2.6.3
+
 ## 0.1.1
 
 ### Include DeepNest in native Ruby classes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    deep_nest (0.1.1)
+    deep_nest (0.1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/deep_nest.gemspec
+++ b/deep_nest.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.summary = "Recursive methods for Ruby structures."
   spec.homepage = "https://github.com/RealmFive/deep_nest"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.2")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.3")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage

--- a/lib/deep_nest/version.rb
+++ b/lib/deep_nest/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeepNest
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end


### PR DESCRIPTION
- Downgrade required Ruby version from 2.7.2 to 2.6.3 in Gemspec
- Upgrade DeepNest version to 1.2
- Log changes in CHANGELOG